### PR TITLE
added signer rule for Google+ notifications

### DIFF
--- a/data/signersDefault.json
+++ b/data/signersDefault.json
@@ -105,6 +105,12 @@
 			"ruletype": "ALL",
 			"priority": "DEFAULT_RULE_ALL_2"
 		}, {
+			"domain": "google.com",
+			"addr": "*@plus.google.com",
+			"sdid": "plus.google.com",
+			"ruletype": "ALL",
+			"priority": "DEFAULT_RULE_ALL_2"
+		}, {
 			"domain": "googlemail.com",
 			"addr": "*",
 			"sdid": "googlemail.com",


### PR DESCRIPTION
Google+ notifications are sent from and signed by the 'plus.google.com' domain. The default 'google.com' rule would give false positives.
