### PR TITLE
Backport: ARH: fixed missing reason on fail resulting in error (#232)

### DIFF
--- a/modules/AuthVerifier.jsm
+++ b/modules/AuthVerifier.jsm
@@ -317,6 +317,7 @@ function getARHResult(msgHdr, msg) {
 		spf: arhSPF,
 		dmarc: arhDMARC,
 	};
+	log.debug("ARH result:", savedAuthResult);
 	return savedAuthResult;
 }
 
@@ -539,79 +540,82 @@ function dkimSigResultV2_to_AuthResultDKIM(dkimSigResult) { // eslint-disable-li
 				authResultDKIM.res_num = 30;
 			}
 			let errorType = dkimSigResult.errorType;
-			if (!prefs.getBoolPref("error.detailedReasons")) {
-				switch (errorType) {
-					case "DKIM_SIGERROR_ILLFORMED_TAGSPEC":
-					case "DKIM_SIGERROR_DUPLICATE_TAG":
-					case "DKIM_SIGERROR_MISSING_V":
-					case "DKIM_SIGERROR_ILLFORMED_V":
-					case "DKIM_SIGERROR_MISSING_A":
-					case "DKIM_SIGERROR_ILLFORMED_A":
-					case "DKIM_SIGERROR_MISSING_B":
-					case "DKIM_SIGERROR_ILLFORMED_B":
-					case "DKIM_SIGERROR_MISSING_BH":
-					case "DKIM_SIGERROR_ILLFORMED_BH":
-					case "DKIM_SIGERROR_ILLFORMED_C":
-					case "DKIM_SIGERROR_MISSING_D":
-					case "DKIM_SIGERROR_ILLFORMED_D":
-					case "DKIM_SIGERROR_MISSING_H":
-					case "DKIM_SIGERROR_ILLFORMED_H":
-					case "DKIM_SIGERROR_SUBDOMAIN_I":
-					case "DKIM_SIGERROR_DOMAIN_I":
-					case "DKIM_SIGERROR_ILLFORMED_I":
-					case "DKIM_SIGERROR_ILLFORMED_L":
-					case "DKIM_SIGERROR_ILLFORMED_Q":
-					case "DKIM_SIGERROR_MISSING_S":
-					case "DKIM_SIGERROR_ILLFORMED_S":
-					case "DKIM_SIGERROR_ILLFORMED_T":
-					case "DKIM_SIGERROR_TIMESTAMPS":
-					case "DKIM_SIGERROR_ILLFORMED_X":
-					case "DKIM_SIGERROR_ILLFORMED_Z":
-						errorType = "DKIM_SIGERROR_ILLFORMED";
-						break;
-					case "DKIM_SIGERROR_VERSION":
-					case "DKIM_SIGERROR_UNKNOWN_A":
-					case "DKIM_SIGERROR_UNKNOWN_C_H":
-					case "DKIM_SIGERROR_UNKNOWN_C_B":
-					case "DKIM_SIGERROR_UNKNOWN_Q":
-						errorType = "DKIM_SIGERROR_UNSUPPORTED";
-						break;
-					case "DKIM_SIGERROR_KEY_ILLFORMED_TAGSPEC":
-					case "DKIM_SIGERROR_KEY_DUPLICATE_TAG":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_V":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_H":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_K":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_N":
-					case "DKIM_SIGERROR_KEY_MISSING_P":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_P":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_S":
-					case "DKIM_SIGERROR_KEY_ILLFORMED_T":
-						errorType = "DKIM_SIGERROR_KEY_ILLFORMED";
-						break;
-					case "DKIM_SIGERROR_KEY_INVALID_V":
-					case "DKIM_SIGERROR_KEY_HASHNOTINCLUDED":
-					case "DKIM_SIGERROR_KEY_UNKNOWN_K":
-					case "DKIM_SIGERROR_KEY_HASHMISMATCH":
-					case "DKIM_SIGERROR_KEY_NOTEMAILKEY":
-					case "DKIM_SIGERROR_KEYDECODE":
-						errorType = "DKIM_SIGERROR_KEY_INVALID";
-						break;
-					case "DKIM_SIGERROR_BADSIG":
-					case "DKIM_SIGERROR_CORRUPT_BH":
-					case "DKIM_SIGERROR_MISSING_FROM":
-					case "DKIM_SIGERROR_TOOLARGE_L":
-					case "DKIM_SIGERROR_NOKEY":
-					case "DKIM_SIGERROR_KEY_REVOKED":
-					case "DKIM_SIGERROR_KEY_TESTMODE":
-						break;
-					default:
-						log.warn("unknown errorType: " + errorType);
+			let errorMsg;
+			if (errorType) {
+				if (!prefs.getBoolPref("error.detailedReasons")) {
+					switch (errorType) {
+						case "DKIM_SIGERROR_ILLFORMED_TAGSPEC":
+						case "DKIM_SIGERROR_DUPLICATE_TAG":
+						case "DKIM_SIGERROR_MISSING_V":
+						case "DKIM_SIGERROR_ILLFORMED_V":
+						case "DKIM_SIGERROR_MISSING_A":
+						case "DKIM_SIGERROR_ILLFORMED_A":
+						case "DKIM_SIGERROR_MISSING_B":
+						case "DKIM_SIGERROR_ILLFORMED_B":
+						case "DKIM_SIGERROR_MISSING_BH":
+						case "DKIM_SIGERROR_ILLFORMED_BH":
+						case "DKIM_SIGERROR_ILLFORMED_C":
+						case "DKIM_SIGERROR_MISSING_D":
+						case "DKIM_SIGERROR_ILLFORMED_D":
+						case "DKIM_SIGERROR_MISSING_H":
+						case "DKIM_SIGERROR_ILLFORMED_H":
+						case "DKIM_SIGERROR_SUBDOMAIN_I":
+						case "DKIM_SIGERROR_DOMAIN_I":
+						case "DKIM_SIGERROR_ILLFORMED_I":
+						case "DKIM_SIGERROR_ILLFORMED_L":
+						case "DKIM_SIGERROR_ILLFORMED_Q":
+						case "DKIM_SIGERROR_MISSING_S":
+						case "DKIM_SIGERROR_ILLFORMED_S":
+						case "DKIM_SIGERROR_ILLFORMED_T":
+						case "DKIM_SIGERROR_TIMESTAMPS":
+						case "DKIM_SIGERROR_ILLFORMED_X":
+						case "DKIM_SIGERROR_ILLFORMED_Z":
+							errorType = "DKIM_SIGERROR_ILLFORMED";
+							break;
+						case "DKIM_SIGERROR_VERSION":
+						case "DKIM_SIGERROR_UNKNOWN_A":
+						case "DKIM_SIGERROR_UNKNOWN_C_H":
+						case "DKIM_SIGERROR_UNKNOWN_C_B":
+						case "DKIM_SIGERROR_UNKNOWN_Q":
+							errorType = "DKIM_SIGERROR_UNSUPPORTED";
+							break;
+						case "DKIM_SIGERROR_KEY_ILLFORMED_TAGSPEC":
+						case "DKIM_SIGERROR_KEY_DUPLICATE_TAG":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_V":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_H":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_K":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_N":
+						case "DKIM_SIGERROR_KEY_MISSING_P":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_P":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_S":
+						case "DKIM_SIGERROR_KEY_ILLFORMED_T":
+							errorType = "DKIM_SIGERROR_KEY_ILLFORMED";
+							break;
+						case "DKIM_SIGERROR_KEY_INVALID_V":
+						case "DKIM_SIGERROR_KEY_HASHNOTINCLUDED":
+						case "DKIM_SIGERROR_KEY_UNKNOWN_K":
+						case "DKIM_SIGERROR_KEY_HASHMISMATCH":
+						case "DKIM_SIGERROR_KEY_NOTEMAILKEY":
+						case "DKIM_SIGERROR_KEYDECODE":
+							errorType = "DKIM_SIGERROR_KEY_INVALID";
+							break;
+						case "DKIM_SIGERROR_BADSIG":
+						case "DKIM_SIGERROR_CORRUPT_BH":
+						case "DKIM_SIGERROR_MISSING_FROM":
+						case "DKIM_SIGERROR_TOOLARGE_L":
+						case "DKIM_SIGERROR_NOKEY":
+						case "DKIM_SIGERROR_KEY_REVOKED":
+						case "DKIM_SIGERROR_KEY_TESTMODE":
+							break;
+						default:
+							log.warn("unknown errorType: " + errorType);
+					}
 				}
-			}
-			let errorMsg =
+				errorMsg =
 				tryGetFormattedString(dkimStrings, errorType,
 					dkimSigResult.errorStrParams) ||
 				errorType;
+			}			
 			if (errorMsg) {
 				authResultDKIM.result_str = dkimStrings.getFormattedString("PERMFAIL",
 					[errorMsg]);

--- a/modules/dkimVerifier.jsm
+++ b/modules/dkimVerifier.jsm
@@ -94,8 +94,8 @@ const PREF_BRANCH = "extensions.dkim_verifier.";
  *           added in version 1.1
  * @property {String[]} [warnings]
  *           required if result="SUCCESS
- * @property {String} [errorType]
- *           if result="PERMFAIL: DKIM_SigError.errorType
+ * @property {String|undefined} [errorType]
+ *           if result="PERMFAIL: DKIM_SigError.errorType or Undefined
  *           if result="TEMPFAIL: DKIM_InternalError.errorType or Undefined
  * @property {String} [shouldBeSignedBy]
  *           added in version 1.1


### PR DESCRIPTION
Fixed the issue from https://github.com/lieser/dkim_verifier/commit/8e7241731ede0fced0d9b56d3ddee94f2e5ef004 in the 2.x branch