### PR TITLE
Use Services global variable

### DIFF
--- a/experiments/JSDNS.jsm.js
+++ b/experiments/JSDNS.jsm.js
@@ -68,7 +68,9 @@ var EXPORTED_SYMBOLS = [
 
 
 // @ts-expect-error
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 
 const LOG_NAME = "DKIM_Verifier.JSDNS";

--- a/experiments/jsdns.js
+++ b/experiments/jsdns.js
@@ -11,13 +11,9 @@
 // @ts-check
 ///<reference path="./jsdns.d.ts" />
 ///<reference path="./mozilla.d.ts" />
-/* global ExtensionCommon */
+/* global ExtensionCommon, Services */
 
 "use strict";
-
-// @ts-expect-error
-// eslint-disable-next-line no-var
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 this.jsdns = class extends ExtensionCommon.ExtensionAPI {
 	/**

--- a/experiments/libunbound.js
+++ b/experiments/libunbound.js
@@ -13,13 +13,10 @@
 // @ts-check
 ///<reference path="./libunbound.d.ts" />
 ///<reference path="./mozilla.d.ts" />
-/* global ExtensionCommon */
+/* global ExtensionCommon, Services */
 
 "use strict";
 
-// @ts-expect-error
-// eslint-disable-next-line no-var
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 // @ts-expect-error
 // eslint-disable-next-line no-var
 var OS;

--- a/experiments/mailUtils.js
+++ b/experiments/mailUtils.js
@@ -10,13 +10,9 @@
 // @ts-check
 ///<reference path="./mailUtils.d.ts" />
 ///<reference path="./mozilla.d.ts" />
-/* global ExtensionCommon */
+/* global ExtensionCommon, Services */
 
 "use strict";
-
-// @ts-expect-error
-// eslint-disable-next-line no-var
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 this.mailUtils = class extends ExtensionCommon.ExtensionAPI {
 	/**

--- a/experiments/migration.js
+++ b/experiments/migration.js
@@ -10,13 +10,10 @@
 // @ts-check
 ///<reference path="./migration.d.ts" />
 ///<reference path="./mozilla.d.ts" />
-/* global ExtensionCommon */
+/* global ExtensionCommon, Services */
 
 "use strict";
 
-// @ts-expect-error
-// eslint-disable-next-line no-var
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 // eslint-disable-next-line no-var
 var { Sqlite } = ChromeUtils.import("resource://gre/modules/Sqlite.jsm");
 // @ts-expect-error


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 91.