### PR TITLE
Favicon and sign rules for PDF-XChange.com

### DIFF
--- a/data/favicon.json
+++ b/data/favicon.json
@@ -417,6 +417,7 @@
 	"paypal.vn": "paypal.com.ico",
 	"payproglobal.com": "payproglobal.com.png",
 	"payu.com": "payu.com.png",
+	"pdf-xchange.com": "tracker-software.com.png",
 	"peek-und-cloppenburg.de": "peek-und-cloppenburg.de.ico",
 	"perdue.com": "perdue.com.ico",
 	"peterhahn.de": "peterhahn.de.png",

--- a/data/signersDefault.json
+++ b/data/signersDefault.json
@@ -2488,6 +2488,18 @@
 			"ruletype": "NEUTRAL",
 			"priority": "DEFAULT_RULE_NEUTRAL"
  		}, {
+			"domain": "pdf-xchange.com",
+			"addr": "*",
+			"sdid": "pdf-xchange.com",
+			"ruletype": "ALL",
+			"priority": "DEFAULT_RULE_ALL"
+		}, {
+			"domain": "pdf-xchange.com",
+			"addr": "support@pdf-xchange.com",
+			"sdid": "pdf-xchange.com",
+			"ruletype": "NEUTRAL",
+			"priority": "DEFAULT_RULE_NEUTRAL"
+		}, {
 			"domain": "pilotprojekt-grundeinkommen.de",
 			"addr": "*",
 			"sdid": "pilotprojekt-grundeinkommen.de",


### PR DESCRIPTION
Tracker Software's default mail domain is pdf-xchange.com now, added rules for favicon and signing