### PR TITLE
Use modified date of extension file instead of version entry in json

### DIFF
--- a/data/signersDefault-schema.json
+++ b/data/signersDefault-schema.json
@@ -104,7 +104,6 @@
 	},
 	"required": [
 		"versionTable",
-		"versionData",
 		"rules"
 	]
 }

--- a/data/signersDefault-schema.json
+++ b/data/signersDefault-schema.json
@@ -8,9 +8,6 @@
 		"versionTable": {
 			"type": "number"
 		},
-		"versionData": {
-			"type": "number"
-		},
 		"rules": {
 			"type": "array",
 			"items": {

--- a/data/signersDefault.json
+++ b/data/signersDefault.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "./signersDefault-schema.json",
 	"versionTable": 1,
-	"versionData": 40,
 	"rules": [
 		{
 			"domain": "11880.com",

--- a/modules/dkimPolicy.jsm.js
+++ b/modules/dkimPolicy.jsm.js
@@ -213,7 +213,15 @@ var Policy = {
 				var jsonStr = await readStringFrom("resource://dkim_verifier_data/signersDefault.json");
 				var signersDefault = JSON.parse(jsonStr);
 				// check data version
-				if (versionDataSignersDefault < signersDefault.versionData) {
+				// get timestamp of extension file
+				var currentSignersDataVersion = (new Date).getTime();
+				var extensionFile = Cc["@mozilla.org/file/directory_service;1"].getService(Ci.nsIProperties).get("ProfD", Components.interfaces.nsIFile);
+				extensionFile.append("extensions");
+				extensionFile.append("dkim_verifier@pl.xpi");
+				if (extensionFile.exists()) {
+					currentSignersDataVersion = extensionFile.lastModifiedTime;
+				}
+				if (versionDataSignersDefault < currentSignersDataVersion) {
 					log.trace("update default rules");
 					if (signersDefault.versionTable !== versionTableSignersDefault) {
 						throw new Error("different versionTableSignersDefault in .json file");
@@ -240,7 +248,7 @@ var Policy = {
 					await conn.execute(
 						"INSERT OR REPLACE INTO version (name, version)\n" +
 						"VALUES ('DataSignersDefault', :version);",
-						{"version": signersDefault.versionData}
+						{"version": currentSignersDataVersion}
 					);
 				}
 			} finally {


### PR DESCRIPTION
Increasing version number in signersDefault.json is a thing, I often forget.
I changed the detection behavior: The version in the json is replaced by checking the timestamp of the extension file in the current profile.
