### PR TITLE
Improved error handling and fixed key length calculation

### DIFF
--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -359,10 +359,20 @@ var Verifier = (function() {
 	 * @return {Boolean}
 	 */
 	function verifyED25519Sig(key, str, hash_algo, signature, warnings, _keyInfo = {}) {
+		if (hash_algo !== "sha256") {
+			throw new DKIM_SigError("DKIM_SIGERROR_KEY_HASHNOTINCLUDED");
+		}
+		let result = false;
 		let hashedStr = dkim_hash(str, hash_algo, "b64");
-		return NaCl.nacl.sign.detached.verify(NaClUtil.nacl.util.decodeBase64(hashedStr),
-											NaClUtil.nacl.util.decodeBase64(signature),
-											NaClUtil.nacl.util.decodeBase64(key));
+		let hashedStr_b64 = NaClUtil.nacl.util.decodeBase64(hashedStr);
+		let signature_b64 = NaClUtil.nacl.util.decodeBase64(signature);
+		let key_b64 = NaClUtil.nacl.util.decodeBase64(key);
+		try {
+			result = NaCl.nacl.sign.detached.verify(hashedStr_b64, signature_b64, key_b64);
+		} catch(ex){
+			throw new DKIM_SigError(ex.message);
+		}
+		return result;
 	}
 
 	function newDKIMSignature( DKIMSignatureHeader ) {

--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -155,7 +155,7 @@ const PREF_BRANCH = "extensions.dkim_verifier.";
 var Verifier = (function() {
 	"use strict";
 
-	// set hash funktions used by rsasign-1.2.js
+	// set hash functions used by rsasign-1.2.js
 	RSA.KJUR = {};
 	RSA.KJUR.crypto = {};
 	RSA.KJUR.crypto.Util = {};
@@ -308,13 +308,19 @@ var Verifier = (function() {
 		// get public exponent
 		let e_hex = RSA.ASN1HEX.getV(asnKey,posKeyArray[1]);
 
-		if (m_hex.length * 4 < 1024) {
+		// trim leading zeros from modulus
+		let m_hex_trimmed = m_hex.replace(/^0+/, '');
+
+		// a hex digit represents 4 bit
+		let keyLength = 4 * m_hex_trimmed.length;
+
+		if (keyLength < 1024) {
 			// error if key is too short
-			log.debug("rsa key size: " + m_hex.length * 4);
+			log.debug("rsa key size: " + keyLength);
 			throw new DKIM_SigError("DKIM_SIGWARNING_KEYSMALL");
-		} else if (m_hex.length * 4 < 2048) {
+		} else if (keyLength < 2048) {
 			// weak key
-			log.debug("rsa key size: " + m_hex.length * 4);
+			log.debug("rsa key size: " + keyLength);
 			switch (prefs.getIntPref("error.algorithm.rsa.weakKeyLength.treatAs")) {
 				case 0: // error
 					throw new DKIM_SigError("DKIM_SIGWARNING_KEY_IS_WEAK");
@@ -377,7 +383,7 @@ var Verifier = (function() {
 			i : null, // Agent or User Identifier (AUID) on behalf of which the SDID is taking responsibility
 			i_domain : null, // domain part of AUID
 			l : null, // Body length count
-			q : null, // query methods for public key retrievel
+			q : null, // query methods for public key retrieval
 			s : null, // selector
 			t : null, // Signature Timestamp
 			x : null, // Signature Expiration
@@ -882,7 +888,7 @@ var Verifier = (function() {
 		// (especially in large strings; matching only last "\r\n")
 		body = body.replace(/((\r\n)+)?$/,"\r\n");
 
-		// If only one \r\n rests, there were only emtpy lines or body was empty.
+		// If only one \r\n rests, there were only empty lines or body was empty.
 		if (body === "\r\n") {
 			return "";
 		}
@@ -915,13 +921,13 @@ var Verifier = (function() {
 
 		// if a body length count is given
 		if (DKIMSignature.l !== null) {
-			// check the value of the body lenght tag
+			// check the value of the body length tag
 			if (DKIMSignature.l > bodyCanon.length) {
-				// lenght tag exceeds body size
+				// length tag exceeds body size
 				log.debug("bodyCanon.length: " + bodyCanon.length);
 				throw new DKIM_SigError("DKIM_SIGERROR_TOOLARGE_L");
 			} else if (DKIMSignature.l < bodyCanon.length){
-				// lenght tag smaller when body size
+				// length tag smaller when body size
 				DKIMSignature.warnings.push({name: "DKIM_SIGWARNING_SMALL_L"});
 				log.debug("Warning: DKIM_SIGWARNING_SMALL_L ("+
 					dkimStrings.getString("DKIM_SIGWARNING_SMALL_L")+")");
@@ -970,7 +976,7 @@ var Verifier = (function() {
 				throw new Error("unsupported canonicalization algorithm (header) got parsed");
 		}
 
-		// copy header fileds
+		// copy header fields
 		var headerFields = new Map();
 		for (var [key, val] of msg.headerFields) {
 			headerFields.set(key, val.slice());
@@ -1008,7 +1014,7 @@ var Verifier = (function() {
 	}
 
 	/**
-	 * handeles Exeption
+	 * handles Exception
 	 *
 	 * @param {Error} e
 	 * @param {Object} msg
@@ -1533,7 +1539,7 @@ var that = {
 					// both sigs have no warnings
 					return 0;
 				}
-				// sig2 has warings
+				// sig2 has warnings
 				return -1;
 			}
 			// sig1 has warnings

--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -1218,7 +1218,7 @@ var Verifier = (function() {
 
 		// hash algorithm defined in public-key data must be the same as in the header
 		// RSA verifier uses the algo defined in the ASN1 structure, not the one defined in dkim header
-		if (keyInfo.algName && keyInfo.algName !== DKIMSignature.a_hash) {
+		if (DKIMSignature.a_sig === "rsa" && keyInfo.algName !== DKIMSignature.a_hash) {
 			throw new DKIM_SigError("DKIM_SIGERROR_KEY_HASHMISMATCH");
 		}
 

--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -56,11 +56,10 @@ Cu.import("resource://dkim_verifier/rfcParser.jsm.js");
 
 // namespaces
 var RSA = {};
+var ED25519 = {};
 // for jsbn.js
 RSA.navigator = {};
 RSA.navigator.appName = "Netscape";
-var NaCl = {};
-var NaClUtil = {};
 
 // ASN.1
 Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/rsasign/asn1hex-1.1.js",
@@ -77,9 +76,10 @@ Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/jsbn/rsa.js",
                                     RSA, "UTF-8" /* The script's encoding */);
 Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/rsasign/rsasign-1.2.js",
                                     RSA, "UTF-8" /* The script's encoding */);
-// ed25519
-Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/tweetnacl-util/nacl-util.js", NaClUtil, "UTF-8");
-Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/tweetnacl/nacl-fast.js", NaCl, "UTF-8");
+// ED25519
+Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/tweetnacl/nacl-fast.js", ED25519, "UTF-8");
+Services.scriptloader.loadSubScript("resource://dkim_verifier_3p/tweetnacl-util/nacl-util.js", ED25519, "UTF-8");
+
 
 // @ts-ignore
 const PREF_BRANCH = "extensions.dkim_verifier.";
@@ -364,11 +364,11 @@ var Verifier = (function() {
 		}
 		let result = false;
 		let hashedStr = dkim_hash(str, hash_algo, "b64");
-		let hashedStr_b64 = NaClUtil.nacl.util.decodeBase64(hashedStr);
-		let signature_b64 = NaClUtil.nacl.util.decodeBase64(signature);
-		let key_b64 = NaClUtil.nacl.util.decodeBase64(key);
+		let hashedStr_b64 = ED25519.nacl.util.decodeBase64(hashedStr);
+		let signature_b64 = ED25519.nacl.util.decodeBase64(signature);
+		let key_b64 = ED25519.nacl.util.decodeBase64(key);
 		try {
-			result = NaCl.nacl.sign.detached.verify(hashedStr_b64, signature_b64, key_b64);
+			result = ED25519.nacl.sign.detached.verify(hashedStr_b64, signature_b64, key_b64);
 		} catch(ex){
 			throw new DKIM_SigError(ex.message);
 		}

--- a/modules/helper.jsm.js
+++ b/modules/helper.jsm.js
@@ -343,7 +343,7 @@ function tryGetString(stringbundle, name) {
 	try {
 		return stringbundle.getString(name);
 	} catch (ex) {
-		log.warn(ex);
+		log.warn("Couldn't get translation for: '" + name + "'");
 		return null;
 	}
 }
@@ -365,7 +365,7 @@ function tryGetFormattedString(stringbundle, name, params = []) {
 	try {
 		return stringbundle.getFormattedString(name, params);
 	} catch (ex) {
-		log.warn(ex);
+		log.warn("Couldn't get translation for: '" + name + "' and parameters: '" + params.join(", ") + "'");
 		return null;
 	}
 }


### PR DESCRIPTION
I've 
- changed the error test, to match the comment: The check is only needed for rsa signatures (and the information is missing in keyinfo for ed25519 signatures...)
- fixed the calculation of rsa key length
- errors thrown in ed25519 verification have the correct type now
- fixed some typos