### PR TITLE
2.x: Prefer ed25519 over rsa signatures

### DIFF
--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -1259,6 +1259,7 @@ var Verifier = (function() {
 			selector : DKIMSignature.s,
 			warnings : DKIMSignature.warnings,
 			keySecure : DKIMSignature.keyQueryResult.secure,
+			algorithmSignature : DKIMSignature.a_sig
 		};
 		return verification_result;
 	}
@@ -1589,6 +1590,20 @@ var that = {
 			return 0;
 		}
 
+		function algo_compare(sig1, sig2) {
+			// prefer ed25519 over rsa
+			if (sig1.algorithmSignature === sig2.algorithmSignature) {
+				// both algorithms are equal
+				return 0;
+			}
+			if (sig1.algorithmSignature === "ed25519") {
+				// there are only ed25519 and rsa allowed, so sig2.a is rsa
+				return -1;
+			}
+			// there are only ed25519 and rsa allowed, so sig2.a is ed25519
+			return 1;
+		}
+
 		signatures.sort(function (sig1, sig2) {
 			let cmp;
 			cmp = result_compare(sig1, sig2);
@@ -1600,6 +1615,10 @@ var that = {
 				return cmp;
 			}
 			cmp = sdid_compare(sig1, sig2);
+			if (cmp !== 0) {
+				return cmp;
+			}
+			cmp = algo_compare(sig1, sig2);
 			if (cmp !== 0) {
 				return cmp;
 			}

--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -1635,7 +1635,6 @@ var that = {
 	 * make handleException public
 	 */
 	handleException : handleException,
-	handleExeption : handleException,
 
 	/*
 	 * make checkForSignatureExsistens public

--- a/modules/dkimVerifier.jsm.js
+++ b/modules/dkimVerifier.jsm.js
@@ -1259,7 +1259,7 @@ var Verifier = (function() {
 			selector : DKIMSignature.s,
 			warnings : DKIMSignature.warnings,
 			keySecure : DKIMSignature.keyQueryResult.secure,
-			algorithmSignature : DKIMSignature.a_sig
+			sigAlgo : DKIMSignature.a_sig
 		};
 		return verification_result;
 	}
@@ -1592,11 +1592,11 @@ var that = {
 
 		function algo_compare(sig1, sig2) {
 			// prefer ed25519 over rsa
-			if (sig1.algorithmSignature === sig2.algorithmSignature) {
+			if (sig1.sigAlgo === sig2.sigAlgo) {
 				// both algorithms are equal
 				return 0;
 			}
-			if (sig1.algorithmSignature === "ed25519") {
+			if (sig1.sigAlgo === "ed25519") {
 				// there are only ed25519 and rsa allowed, so sig2.a is rsa
 				return -1;
 			}


### PR DESCRIPTION
This changes the signature sort behavior, such that an ed25519 signature will be preferred over a corresponding rsa signature.

For any ed25519 signature, there's a corresponding rsa signature for backward compatibility; 
in the case that weak rsa keys are handled as warning and the ed25519 signature also produces a warning, it might happen, that the rsa signature is ranked first and therefore a weak key warning appeared in spite of a valid ed25519 signature is in place.