### PR TITLE
2.x: Fix a display issue with Silvermel theme

### DIFF
--- a/chrome/skin/global/msgHdrViewOverlay.css
+++ b/chrome/skin/global/msgHdrViewOverlay.css
@@ -18,12 +18,24 @@
   display: none;
 }
 
+#expandeddkim-verifierBox:not([spf="false"])  [anonid="spf"] {
+  display: contents;
+}
+
 #expandeddkim-verifierBox:not([dmarc="true"])  [anonid="dmarc"] {
   display: none;
 }
 
+#expandeddkim-verifierBox:not([dmarc="false"])  [anonid="dmarc"] {
+  display: contents;
+}
+
 #expandeddkim-verifierBox:not([arhDkim="true"])  [anonid="arhDkim"] {
   display: none;
+}
+
+#expandeddkim-verifierBox:not([arhDkim="false"])  [anonid="arhDkim"] {
+  display: contents;
 }
 
 mail-multi-emailHeaderField {

--- a/chrome/skin/global/msgHdrViewOverlay.css
+++ b/chrome/skin/global/msgHdrViewOverlay.css
@@ -18,7 +18,7 @@
   display: none;
 }
 
-#expandeddkim-verifierBox:not([spf="false"])  [anonid="spf"] {
+#expandeddkim-verifierBox[spf="true"]  [anonid="spf"] {
   display: contents;
 }
 
@@ -26,7 +26,7 @@
   display: none;
 }
 
-#expandeddkim-verifierBox:not([dmarc="false"])  [anonid="dmarc"] {
+#expandeddkim-verifierBox[dmarc="true"]  [anonid="dmarc"] {
   display: contents;
 }
 
@@ -34,7 +34,7 @@
   display: none;
 }
 
-#expandeddkim-verifierBox:not([arhDkim="false"])  [anonid="arhDkim"] {
+#expandeddkim-verifierBox[arhDkim="true"]  [anonid="arhDkim"] {
   display: contents;
 }
 


### PR DESCRIPTION
When ARH headers were displayed, SPF and DMARC field did overlay using silvermel theme