### PR TITLE
2.x: Improved ARH results display 2025-02-07

### DIFF
--- a/chrome/content/dkim.js
+++ b/chrome/content/dkim.js
@@ -242,7 +242,7 @@ DKIM_Verifier.Display = (function() {
 		that.setCollapsed(result.dkim[0].res_num);
 		header.value = result.dkim[0].result_str;
 
-		let sigCount = 0;
+		let resultCount = 0;
 		let detailsHint;
 		if (prefs.getBoolPref("advancedInfo.show")) {
 			detailsHint	= "";
@@ -250,10 +250,10 @@ DKIM_Verifier.Display = (function() {
 				result.dkim.forEach(dkim => {
 					if (dkim.details_str) {
 						detailsHint += "\n----\n" + dkim.details_str;
-						sigCount += 1;
+						resultCount += 1;
 					}
 				});
-				if (sigCount === 0) {
+				if (resultCount === 0) {
 					// the check resulted in an error, because the signature wasn't well formed
 					// or there was no signature
 					detailsHint = undefined;
@@ -265,7 +265,11 @@ DKIM_Verifier.Display = (function() {
 				// there is extended information to display
 				let caption = "";
 				if (prefs.getBoolPref("advancedInfo.allSignatures")) {
-					caption = dkimStrings.getFormattedString("DKIM_RESULT_DETAILS_SIG_COUNT", [sigCount]);
+					let resultStr = "DKIM_RESULT_DETAILS_SIG_COUNT";
+					if (prefs.getBoolPref("arh.replaceAddonResult")) {
+						resultStr = "DKIM_RESULT_DETAILS_HEADER_COUNT";
+					}
+					caption = dkimStrings.getFormattedString(resultStr, [resultCount]);
 				}
 				detailsHint = caption + detailsHint;
 			}

--- a/chrome/content/options_advanced.js
+++ b/chrome/content/options_advanced.js
@@ -1,0 +1,31 @@
+// @ts-nocheck
+/* eslint-env browser */
+/* eslint strict: ["warn", "function"] */
+/* exported gDKIMOptionsAdvancedPane.toggleARHOptionsEnabled */
+
+let gDKIMOptionsAdvancedPane = {
+	initDone : false,
+
+	checkBox : {
+		replaceAddonResult : null,
+		showDKIMResults : null
+	},
+
+	init : function() {
+		"use strict";
+		if (gDKIMOptionsAdvancedPane.initDone) { return; }
+		gDKIMOptionsAdvancedPane.checkBox.replaceAddonResult = document.getElementById("advanced.arh.replaceAddonResult");
+		gDKIMOptionsAdvancedPane.checkBox.showDKIMResults = document.getElementById("advanced.arh.showDKIMResults");
+		gDKIMOptionsAdvancedPane.toggleARHOptionsEnabled();
+		gDKIMOptionsAdvancedPane.initDone = true;
+	},
+
+	toggleARHOptionsEnabled : function() {
+		"use strict";
+		if (gDKIMOptionsAdvancedPane.checkBox.replaceAddonResult.checked) { gDKIMOptionsAdvancedPane.checkBox.showDKIMResults.checked = true; }
+		gDKIMOptionsAdvancedPane.checkBox.showDKIMResults.disabled = gDKIMOptionsAdvancedPane.checkBox.replaceAddonResult.checked;
+	}
+
+};
+
+window.addEventListener("paneload", gDKIMOptionsAdvancedPane.init, false);

--- a/chrome/content/options_advanced.xul
+++ b/chrome/content/options_advanced.xul
@@ -3,7 +3,7 @@
 <!DOCTYPE overlay SYSTEM "chrome://dkim_verifier/locale/options.dtd">
 
 <overlay xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-
+<script type="application/javascript" src="chrome://dkim_verifier/content/options_advanced.js"/>
 <prefpane id="paneAdvanced" onpaneload="onLoad('paneAdvanced');">
 	<preferences>
 		<preference id="pref_debug"
@@ -20,6 +20,9 @@
 		            type="bool"/>
 		<preference id="pref_arh.replaceAddonResult"
 		            name="extensions.dkim_verifier.arh.replaceAddonResult"
+		            type="bool"/>
+		<preference id="pref_arh.showDKIMResults"
+		            name="extensions.dkim_verifier.arh.showDKIMResults"
 		            type="bool"/>
 		<preference id="pref_arh.relaxedParsing"
 		            name="extensions.dkim_verifier.arh.relaxedParsing"
@@ -50,8 +53,10 @@
 	          label="&error.key_testmode.ignore.label;"/>
 	<checkbox preference="pref_display.keySecure"
 	          label="&display.keySecure.label;"/>
-	<checkbox preference="pref_arh.replaceAddonResult"
+	<checkbox preference="pref_arh.replaceAddonResult" id="advanced.arh.replaceAddonResult" oncommand="gDKIMOptionsAdvancedPane.toggleARHOptionsEnabled()"
 	          label="&arh.replaceAddonResult.label;"/>
+	<checkbox preference="pref_arh.showDKIMResults" id="advanced.arh.showDKIMResults"
+	          label="&arh.showDKIMResults.label;"/>
 	<checkbox preference="pref_arh.relaxedParsing"
 	          label="&arh.relaxedParsing.label;"/>
 	<checkbox preference="pref_error.sanitizeSubject"

--- a/chrome/content/options_display.js
+++ b/chrome/content/options_display.js
@@ -1,27 +1,34 @@
 // @ts-nocheck
 /* eslint-env browser */
 /* eslint strict: ["warn", "function"] */
-/* exported toggleDetailsOptionsEnabled */
+/* exported gDKIMOptionsDisplayPane.toggleDetailsOptionsEnabled */
 
-let checkBox = {
-	showAdvancedInfo : null,
-	allSignatures : null,
-	includeHeaders : null
+let gDKIMOptionsDisplayPane = {
+	initDone : false,
+
+	checkBox : {
+		showAdvancedInfo : null,
+		allSignatures : null,
+		includeHeaders : null
+	},
+
+	init: function() {
+		"use strict";
+		if (gDKIMOptionsDisplayPane.initDone) { return; }
+		gDKIMOptionsDisplayPane.checkBox.showAdvancedInfo = document.getElementById("display.advancedInfo.show");
+		gDKIMOptionsDisplayPane.checkBox.allSignatures = document.getElementById("display.advancedInfo.allSignatures");
+		gDKIMOptionsDisplayPane.checkBox.includeHeaders = document.getElementById("display.advancedInfo.includeHeaders");
+		gDKIMOptionsDisplayPane.toggleDetailsOptionsEnabled();
+		gDKIMOptionsDisplayPane.initDone = true;
+	},
+
+	toggleDetailsOptionsEnabled: function() {
+		"use strict";
+		let disabled = !gDKIMOptionsDisplayPane.checkBox.showAdvancedInfo.checked;
+		gDKIMOptionsDisplayPane.checkBox.allSignatures.disabled = disabled;
+		gDKIMOptionsDisplayPane.checkBox.includeHeaders.disabled = disabled;
+	}
+
 };
 
-function init() {
-	"use strict";
-	checkBox.showAdvancedInfo = document.getElementById("display.advancedInfo.show");
-	checkBox.allSignatures = document.getElementById("display.advancedInfo.allSignatures");
-	checkBox.includeHeaders = document.getElementById("display.advancedInfo.includeHeaders");
-	toggleDetailsOptionsEnabled();
-}
-
-function toggleDetailsOptionsEnabled() {
-	"use strict";
-	let disabled = !checkBox.showAdvancedInfo.checked;
-	checkBox.allSignatures.disabled = disabled;
-	checkBox.includeHeaders.disabled = disabled;
-}
-
-window.addEventListener("load", init, false);
+window.addEventListener("paneload", gDKIMOptionsDisplayPane.init, false);

--- a/chrome/content/options_display.xul
+++ b/chrome/content/options_display.xul
@@ -196,7 +196,7 @@
 	<groupbox>
 		<checkbox preference="pref_display.advancedInfo.show"
 				  label="&display.advancedInfo.show.label;"
-				  oncommand="toggleDetailsOptionsEnabled();"
+				  oncommand="gDKIMOptionsDisplayPane.toggleDetailsOptionsEnabled();"
 				  id="display.advancedInfo.show" />
 		<vbox class="indent">
 			<checkbox preference="pref_display.advancedInfo.allSignatures"

--- a/chrome/locale/de/dkim.properties
+++ b/chrome/locale/de/dkim.properties
@@ -110,6 +110,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Der Betreff wurde verändert: '%S'
 SUCCESS_FROM_ARH = Gültig (Signiert durch %S, geprüft durch %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Anzahl der Authentication-Results-Kopfzeilen: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Anzahl der Signaturen: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signiert durch %S für %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signatur wurde geprüft durch %S

--- a/chrome/locale/de/options.dtd
+++ b/chrome/locale/de/options.dtd
@@ -88,6 +88,7 @@
 
 <!ENTITY arh.read.label "Lese Authentication-Results-Kopfzeile">
 <!ENTITY arh.replaceAddonResult.label "Das Lesen der Authentication-Results-Kopfzeile ersetzt die Prüfung durch das Add-on">
+<!ENTITY arh.showDKIMResults.label "DKIM-Ergebnis aus Authentication-Results-Kopfzeile anzeigen">
 <!ENTITY arh.relaxedParsing.label "Versuche Authentication-Results-Kopfzeilen zu lesen, die nicht RFC-konform sind">
 
 <!ENTITY acc.dkim.enable.label "Überprüfe DKIM-Signaturen:">

--- a/chrome/locale/en-US/dkim.properties
+++ b/chrome/locale/en-US/dkim.properties
@@ -110,6 +110,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Subject was modified: '%S'
 SUCCESS_FROM_ARH = Valid (Signed by %S, verified by %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Authentication Result Headers: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Signature count: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signed by %S for %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signature was verified by %S

--- a/chrome/locale/en-US/options.dtd
+++ b/chrome/locale/en-US/options.dtd
@@ -87,7 +87,8 @@
 <!ENTITY display.keySecure.label "Indicate successful DNSSEC validation with a lock after the SDID">
 
 <!ENTITY arh.read.label "Read Authentication-Results header">
-<!ENTITY arh.replaceAddonResult.label "Reading the Authentication-Results header replaces the add-ons verification">
+<!ENTITY arh.replaceAddonResult.label "Reading the Authentication Results header replaces the add-ons verification">
+<!ENTITY arh.showDKIMResults.label "Show DKIM result from Authentication Results header">
 <!ENTITY arh.relaxedParsing.label "Try to read non RFC compliant Authentication-Results header">
 
 <!ENTITY acc.dkim.enable.label "Verify DKIM signatures:">

--- a/chrome/locale/fr/dkim.properties
+++ b/chrome/locale/fr/dkim.properties
@@ -110,6 +110,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Subject was modified: '%S'
 SUCCESS_FROM_ARH = Valid (Signed by %S, verified by %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Authentication Result Headers: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Signature count: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signed by %S for %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signature was verified by %S

--- a/chrome/locale/fr/options.dtd
+++ b/chrome/locale/fr/options.dtd
@@ -88,6 +88,7 @@
 
 <!ENTITY arh.read.label "Lecture du résultat de l'authentification de l'entête">
 <!ENTITY arh.replaceAddonResult.label "Lecture de l'en-tête Authentication-Results pour remplacer la vérification des add-ons">
+<!ENTITY arh.showDKIMResults.label "Show DKIM result from Authentication Results header">
 <!ENTITY arh.relaxedParsing.label "Essayer de lire une entête Authentication-Results non conforme à la RFC">
 
 <!ENTITY acc.dkim.enable.label "Vérifier les signatures DKIM:">

--- a/chrome/locale/hu/dkim.properties
+++ b/chrome/locale/hu/dkim.properties
@@ -110,6 +110,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Subject was modified: '%S'
 SUCCESS_FROM_ARH = Valid (Signed by %S, verified by %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Authentication Result Headers: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Signature count: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signed by %S for %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signature was verified by %S

--- a/chrome/locale/hu/options.dtd
+++ b/chrome/locale/hu/options.dtd
@@ -88,6 +88,7 @@
 
 <!ENTITY arh.read.label "Olvassa el a hitelesítési-eredmények fejlécet">
 <!ENTITY arh.replaceAddonResult.label "A hitelesítési-eredmények fejléc elolvasása helyettesíti a kiegészítők ellenőrzését">
+<!ENTITY arh.showDKIMResults.label "Show DKIM result from Authentication Results header">
 <!ENTITY arh.relaxedParsing.label "Próbálja meg elolvasni a nem RFC-kompatibilis hitelesítési-eredmények fejlécet">
 
 <!ENTITY acc.dkim.enable.label "Ellenőrizze a DKIM aláírásait:">

--- a/chrome/locale/it/dkim.properties
+++ b/chrome/locale/it/dkim.properties
@@ -110,6 +110,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Subject was modified: '%S'
 SUCCESS_FROM_ARH = Valid (Signed by %S, verified by %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Authentication Result Headers: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Signature count: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signed by %S for %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signature was verified by %S

--- a/chrome/locale/it/options.dtd
+++ b/chrome/locale/it/options.dtd
@@ -88,6 +88,7 @@
 
 <!ENTITY arh.read.label "Leggi l’intestazione Authentication-Results">
 <!ENTITY arh.replaceAddonResult.label "La lettura dell’intestazione Authentication-Results sostituisce la verifica del componente aggiuntivo">
+<!ENTITY arh.showDKIMResults.label "Show DKIM result from Authentication Results header">
 <!ENTITY arh.relaxedParsing.label "Prova a caricare intestazioni Authentication-Results non conformi all’RFC">
 
 <!ENTITY acc.dkim.enable.label "Verifica le firme DKIM:">

--- a/chrome/locale/ja-JP/dkim.properties
+++ b/chrome/locale/ja-JP/dkim.properties
@@ -110,6 +110,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Subject was modified: '%S'
 SUCCESS_FROM_ARH = Valid (Signed by %S, verified by %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Authentication Result Headers: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Signature count: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signed by %S for %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signature was verified by %S

--- a/chrome/locale/ja-JP/options.dtd
+++ b/chrome/locale/ja-JP/options.dtd
@@ -88,6 +88,7 @@
 
 <!ENTITY arh.read.label "Authentication-Results ヘッダを確認">
 <!ENTITY arh.replaceAddonResult.label "Authentication-Results の確認をアドオンによる検証に置き換え">
+<!ENTITY arh.showDKIMResults.label "Show DKIM result from Authentication Results header">
 <!ENTITY arh.relaxedParsing.label "RFC 非準拠の Authentication-Results ヘッダのパースを試みる">
 
 <!ENTITY acc.dkim.enable.label "DKIM 署名の検証:">

--- a/chrome/locale/zh-CN/dkim.properties
+++ b/chrome/locale/zh-CN/dkim.properties
@@ -106,6 +106,7 @@ DKIM_SIGERROR_SUBJECT_MODIFIED	= Subject was modified: '%S'
 SUCCESS_FROM_ARH = Valid (Signed by %S, verified by %S)
 
 # DKIM Result Details
+DKIM_RESULT_DETAILS_HEADER_COUNT = Authentication Result Headers: %S
 DKIM_RESULT_DETAILS_SIG_COUNT = Signature count: %S
 DKIM_RESULT_DETAILS_SIGNED_BY_FOR = Signed by %S for %S
 DKIM_RESULT_DETAILS_VERIFIED_BY = Signature was verified by %S

--- a/chrome/locale/zh-CN/options.dtd
+++ b/chrome/locale/zh-CN/options.dtd
@@ -69,6 +69,7 @@
 <!ENTITY display.keySecure.label "在 SDID 后面用锁标识成功的 DNSSEC 验证">
 <!ENTITY arh.read.label "阅读 Authentication-Results 报头">
 <!ENTITY arh.replaceAddonResult.label "读取 Authentication-Results 头替换本附加组件的验证">
+<!ENTITY arh.showDKIMResults.label "Show DKIM result from Authentication Results header">
 <!ENTITY arh.relaxedParsing.label "尝试读取非兼容 RFC 的 Authentication-Results 头">
 <!ENTITY acc.dkim.enable.label "验证 DKIM 签名:">
 <!ENTITY acc.arh.read.label "读取 Authentication-Results 头:">

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -139,6 +139,7 @@ pref("extensions.dkim_verifier.debugLevel", 0);
 pref("extensions.dkim_verifier.error.detailedReasons", false);
 pref("extensions.dkim_verifier.display.keySecure", true);
 pref("extensions.dkim_verifier.arh.replaceAddonResult", true);
+pref("extensions.dkim_verifier.arh.showDKIMResults", true);
 pref("extensions.dkim_verifier.arh.relaxedParsing", false);
 // 0: error, 1: warning, 2: ignore
 pref("extensions.dkim_verifier.error.illformed_i.treatAs", 1);

--- a/modules/AuthVerifier.jsm.js
+++ b/modules/AuthVerifier.jsm.js
@@ -166,14 +166,16 @@ var AuthVerifier = {
 				if (prefs.getBoolPref("arh.replaceAddonResult")) {
 					savedAuthResult = arhResult;
 				} else {
+					let arhProperty = {};
+					if (prefs.getBoolPref("arh.showDKIMResults")) {
+						arhProperty.dkim = arhResult.dkim;
+					}
 					savedAuthResult = {
 						version: "3.1",
 						dkim: [],
 						spf: arhResult.spf,
 						dmarc: arhResult.dmarc,
-						arh: {
-							dkim: arhResult.dkim
-						},
+						arh: arhProperty,
 						bimiIndicator: arhResult.bimiIndicator,
 					};
 				}


### PR DESCRIPTION
- In the details, the tooltip header is now different for signatures and ARH results
- There's an option to disable the display of ARH DKIM results, so that the addon's DKIM verification can be combined with SPF, DMARC and BIMI from ARH. Before, you had the DKIM result from the addon and the DKIM result from the ARH in this scenario