### PR TITLE
This fixes the display of sign rules in the addin's options

### DIFF
--- a/chrome/content/treeviewKeys.xul
+++ b/chrome/content/treeviewKeys.xul
@@ -40,7 +40,7 @@ function setView(){
 </tree>
 
 <hbox>
-	<button 
+	<button
 	        label="&treeviewKeys.deleteSelectedRows.label;"
 	        oncommand="treeView.deleteSelectedRows();"/>
 	<spacer/>

--- a/modules/SQLiteTreeView.jsm.js
+++ b/modules/SQLiteTreeView.jsm.js
@@ -1,5 +1,5 @@
 /*
- * sqLiteTreeView.jsm.js
+ * SQLiteTreeView.jsm.js
  *
  * Implements a nsITreeView for a SQLite DB table.
  *


### PR DESCRIPTION
Sorry, I broke this some commits ago, while adapting file name cases.