### PR TITLE
Update Swedish translation

### DIFF
--- a/_locales/sv_SE/messages.json
+++ b/_locales/sv_SE/messages.json
@@ -1,7 +1,7 @@
 {
 	// DKIM_STRINGS
 	"loading": {
-		"message": "Validerar..."
+		"message": "Verifierar…"
 	},
 	"SUCCESS": {
 		"message": "Giltig (signerad av $1)"
@@ -13,7 +13,7 @@
 		"message": "Ogiltig"
 	},
 	"TEMPFAIL": {
-		"message": "Tillfälligt valideringsfel (för signaturen av $1)"
+		"message": "Tillfälligt verifieringsfel (för signatur från $1)"
 	},
 	"NOSIG": {
 		"message": "Ingen signatur"
@@ -21,7 +21,22 @@
 	"NOT_EMAIL": {
 		"message": "Meddelandet är inte ett e-postmeddelande"
 	},
+	"SUCCESS_TAG": {
+		"message": "DKIM-signerad av $1",
+		"description": "Tag shown in Conversation add-on for valid mail. Should be kept short."
+	},
+	"TEMPFAIL_TAG": {
+		"message": "DKIM-fel",
+		"description": "Tag shown in Conversation add-on for temporary failure. Should be kept short."
+	},
+	"PERMFAIL_TAG": {
+		"message": "Ogiltig DKIM",
+		"description": "Tag shown in Conversation add-on for invalid mail. Should be kept short."
+	},
 	// DKIM_INTERNALERROR
+	"DKIM_INTERNALERROR": {
+		"message": "Internt fel i DKIM Verifier"
+	},
 	"DKIM_INTERNALERROR_NAME": {
 		"message": "Internt fel"
 	},
@@ -29,34 +44,267 @@
 		"message": "fel"
 	},
 	"DKIM_INTERNALERROR_INCORRECT_EMAIL_FORMAT": {
-		"message": "E-postmeddelandet är inte formaterat på rätt sätt"
+		"message": "E-postmeddelandet är felaktigt formaterat"
+	},
+	"DKIM_INTERNALERROR_INCORRECT_FROM": {
+		"message": "Från-adressen är felaktigt utformad"
+	},
+	"ERROR_IMPORT_RULES": {
+		"message": "Det gick inte att importera signeringsregler.",
+		"description": "Error title if importing of sign rules failed."
+	},
+	"ERROR_IMPORT_RULES_UNKNOWN_DATA": {
+		"message": "Den importerade filens format är ogiltigt.",
+		"description": "Error message if the user tries to import some unknown data as sign rules."
+	},
+	"ERROR_IMPORT_RULES_UNSUPPORTED_FORMAT": {
+		"message": "Signeringsreglernas format har en version som inte stöds.",
+		"description": "Error message if the sign rules the user tried to import have an unsupported format."
 	},
 	// DKIM_INTERNALERROR - DNS
+	"DKIM_DNSERROR_UNKNOWN": {
+		"message": "Fel i DNS-resolvern"
+	},
+	"DKIM_DNSERROR_OFFLINE": {
+		"message": "Det gick inte att göra en DNS-förfrågan eftersom Thunderbird är i frånkopplat läge.",
+		"description": "Error message if the addon needs to do a DNS query, but Thunderbird is in the offline mode."
+	},
+	"DKIM_DNSERROR_SERVER_ERROR": {
+		"message": "Fel vid anslutning till DNS-servern"
+	},
+	"DKIM_DNSERROR_DNSSEC_BOGUS": {
+		"message": "DNS-resultatet är ogiltigt"
+	},
 	// DKIM_SIGERROR
+	"DKIM_SIGERROR": {
+		"message": "Fel i DKIM-signaturen"
+	},
 	"DKIM_SIGERROR_DEFAULT": {
 		"message": "fel"
 	},
 	// DKIM_SIGERROR - DKIM-Signature Header
+	"DKIM_SIGERROR_ILLFORMED": {
+		"message": "Signaturen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_UNSUPPORTED": {
+		"message": "Signaturens version stöds inte"
+	},
+	"DKIM_SIGERROR_ILLFORMED_TAGSPEC": {
+		"message": "Signaturen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_DUPLICATE_TAG": {
+		"message": "Signaturen är felaktigt utformad (duplicerad tagg)"
+	},
+	"DKIM_SIGERROR_VERSION": {
+		"message": "Versionen stöds inte"
+	},
 	"DKIM_SIGERROR_MISSING_V": {
 		"message": "DKIM-versionen saknas"
+	},
+	"DKIM_SIGERROR_ILLFORMED_V": {
+		"message": "Versionstaggen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_MISSING_A": {
+		"message": "Signaturalgoritm saknas"
+	},
+	"DKIM_SIGERROR_UNKNOWN_A": {
+		"message": "Signaturalgoritmen stöds inte"
+	},
+	"DKIM_SIGERROR_INSECURE_A": {
+		"message": "Osäker signaturalgoritm"
+	},
+	"DKIM_SIGERROR_ILLFORMED_A": {
+		"message": "Algoritmtaggen är felaktigt utformad"
 	},
 	"DKIM_SIGERROR_MISSING_B": {
 		"message": "Signatur saknas"
 	},
 	"DKIM_SIGERROR_BADSIG": {
-		"message": "Signaturen är fel"
+		"message": "Signaturen är ogiltig"
+	},
+	"DKIM_SIGERROR_ILLFORMED_B": {
+		"message": "Taggen för signaturdata är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_MISSING_BH": {
+		"message": "Kontrollsumma för meddelandetexten saknas"
 	},
 	"DKIM_SIGERROR_CORRUPT_BH": {
-		"message": "E-postmeddelandet ändrades"
+		"message": "E-postmeddelandet har ändrats"
+	},
+	"DKIM_SIGERROR_ILLFORMED_BH": {
+		"message": "Taggen för meddelandetextens kontrollsumma är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_UNKNOWN_C_H": {
+		"message": "Kanoniseringsalgoritmen för huvudfält stöds inte"
+	},
+	"DKIM_SIGERROR_UNKNOWN_C_B": {
+		"message": "Kanoniseringsalgoritmen för meddelandetexten stöds inte"
+	},
+	"DKIM_SIGERROR_ILLFORMED_C": {
+		"message": "Kanoniseringstaggen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_MISSING_D": {
+		"message": "Identifierare för signeringsdomän (SDID) saknas"
+	},
+	"DKIM_SIGERROR_ILLFORMED_D": {
+		"message": "SDID-taggen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_MISSING_H": {
+		"message": "Signerade huvudfält saknas"
+	},
+	"DKIM_SIGERROR_MISSING_FROM": {
+		"message": "Från-huvudfältet är inte signerat"
+	},
+	"DKIM_SIGERROR_ILLFORMED_H": {
+		"message": "Taggen för signerade huvudfält är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_SUBDOMAIN_I": {
+		"message": "AUID tillhör inte en underdomän till SDID"
+	},
+	"DKIM_SIGERROR_DOMAIN_I": {
+		"message": "AUID måste tillhöra samma domän som SDID (s-flaggan är angiven i nyckelposten)"
+	},
+	"DKIM_SIGERROR_ILLFORMED_I": {
+		"message": "AUID-taggen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_TOOLARGE_L": {
+		"message": "E-postmeddelandet är kortare än vad som anges i DKIM-signaturen"
+	},
+	"DKIM_SIGERROR_ILLFORMED_L": {
+		"message": "Taggen för meddelandetextens längd är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_UNKNOWN_Q": {
+		"message": "Metoden för att hämta den offentliga nyckeln stöds inte"
+	},
+	"DKIM_SIGERROR_ILLFORMED_Q": {
+		"message": "Taggen för frågemetod är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_MISSING_S": {
+		"message": "Väljartagg saknas"
+	},
+	"DKIM_SIGERROR_ILLFORMED_S": {
+		"message": "Väljartaggen är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_ILLFORMED_T": {
+		"message": "Taggen för signaturens tidsstämpel är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_TIMESTAMPS": {
+		"message": "Signaturen upphör att gälla före signaturens tidsstämpel"
+	},
+	"DKIM_SIGERROR_ILLFORMED_X": {
+		"message": "Taggen för signaturens utgångstid är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_ILLFORMED_Z": {
+		"message": "Taggen för kopierade huvudfält är felaktigt utformad"
 	},
 	// DKIM_SIGERROR - key query
+	"DKIM_SIGERROR_NOKEY": {
+		"message": "Ingen DKIM-nyckel hittades på DNS-servern"
+	},
 	// DKIM_SIGERROR - Key record
+	"DKIM_SIGERROR_KEY_ILLFORMED": {
+		"message": "DKIM-nyckeln är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_INVALID": {
+		"message": "DKIM-nyckeln är ogiltig"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_TAGSPEC": {
+		"message": "DKIM-nyckeln är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_DUPLICATE_TAG": {
+		"message": "DKIM-nyckeln är felaktigt utformad (duplicerad tagg)"
+	},
+	"DKIM_SIGERROR_KEY_INVALID_V": {
+		"message": "DKIM-nyckelpostens version är ogiltig"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_V": {
+		"message": "DKIM-nyckelns versionstagg är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_HASHNOTINCLUDED": {
+		"message": "Fel hash-algoritm i DKIM-nyckelposten"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_H": {
+		"message": "Taggen för hash-algoritmer i DKIM-nyckeln är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_UNKNOWN_K": {
+		"message": "DKIM-nyckeltypen stöds inte"
+	},
+	"DKIM_SIGERROR_KEY_MISMATCHED_K": {
+		"message": "Signaturalgoritmen motsvarar inte DKIM-nyckeltypen",
+		"description": "Error message if the signature algorithm in the DKIM Signature header (a-tag) does not match the key type of the DKIM key (k-tag)."
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_K": {
+		"message": "Taggen för DKIM-nyckeltyp är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_N": {
+		"message": "Anteckningstaggen i DKIM-nyckeln är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_MISSING_P": {
+		"message": "DKIM-nyckeln innehåller ingen offentlig nyckel"
+	},
+	"DKIM_SIGERROR_KEY_REVOKED": {
+		"message": "DKIM-nyckeln har återkallats"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_P": {
+		"message": "Taggen för den offentliga nyckelns data är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_NOTEMAILKEY": {
+		"message": "DKIM-nyckeln är inte en e-postnyckel"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_S": {
+		"message": "Taggen för tjänstetyp i DKIM-nyckeln är felaktigt utformad"
+	},
+	"DKIM_SIGERROR_KEY_TESTMODE": {
+		"message": "Signeringsdomänen testar endast DKIM"
+	},
+	"DKIM_SIGERROR_KEY_ILLFORMED_T": {
+		"message": "Flaggtaggen i DKIM-nyckeln är felaktigt utformad"
+	},
 	// DKIM_SIGERROR - key decode
+	"DKIM_SIGERROR_KEYDECODE": {
+		"message": "Den offentliga nyckeln i DKIM-nyckeln kunde inte avkodas"
+	},
 	// DKIM_SIGERROR - POLICY
 	"DKIM_POLICYERROR_MISSING_SIG": {
-		"message": "Bör signeras av $1"
+		"message": "Ingen signatur; meddelandet bör vara signerat av $1",
+		"description": "Error if a message has no signature, but the sign rules state that it should be signed"
+	},
+	"DKIM_POLICYERROR_KEYMISMATCH": {
+		"message": "Den lagrade DKIM-nyckeln skiljer sig från den aktuella"
+	},
+	"DKIM_POLICYERROR_KEY_INSECURE": {
+		"message": "DKIM-nyckeln är inte signerad med DNSSEC"
+	},
+	"DKIM_POLICYERROR_WRONG_SDID": {
+		"message": "Fel signerare (bör vara $1)"
+	},
+	"DKIM_POLICYERROR_UNSIGNED_HEADER_ADDED": {
+		"message": "Det osignerade huvudfältet ”$1” har lagts till",
+		"description": "Error if an important header was probably maliciously added later"
 	},
 	// DKIM_SIGWARNING
+	"DKIM_SIGWARNING_SMALL_L": {
+		"message": "Hela e-postmeddelandet är inte signerat"
+	},
+	"DKIM_SIGWARNING_EXPIRED": {
+		"message": "Signaturen har upphört att gälla"
+	},
+	"DKIM_SIGWARNING_FUTURE": {
+		"message": "Signaturens tidsstämpel ligger i framtiden"
+	},
+	"DKIM_SIGWARNING_KEYSMALL": {
+		"message": "Signaturen är osäker (för liten nyckelstorlek)"
+	},
+	"DKIM_SIGWARNING_KEY_IS_WEAK": {
+		"message": "Signerad med en svag nyckel"
+	},
+	"DKIM_SIGWARNING_FROM_NOT_IN_SDID": {
+		"message": "Från-adressen tillhör inte signeringsdomänen"
+	},
+	"DKIM_SIGWARNING_UNSIGNED_HEADER": {
+		"message": "Huvudfältet ”$1” är inte signerat",
+		"description": "Warning if an important header is not signed"
+	},
 	// JSDNS
 	"TOO_MANY_HOPS": {
 		"message": "För många hopp."
@@ -64,8 +312,11 @@
 	"CONNECTION_REFUSED": {
 		"message": "DNS-servern $1 nekade en TCP-anslutning."
 	},
+	"TIMED_OUT": {
+		"message": "Tidsgränsen för TCP-anslutningen till DNS-servern $1 överskreds."
+	},
 	"SERVER_ERROR": {
-		"message": "Fel uppstod vid anslutning till DNS-servern $1."
+		"message": "Fel vid anslutning till DNS-servern $1."
 	},
 	"INCOMPLETE_RESPONSE": {
 		"message": "Ofullständigt svar från $1."
@@ -91,18 +342,44 @@
 	"options_key.storing.value.1": {
 		"message": "Lagra DKIM-nycklar"
 	},
+	"options_key.storing.value.2": {
+		"message": "Lagra DKIM-nycklar och jämför dem med den aktuella nyckeln"
+	},
 	"options_key.viewKeys": {
 		"message": "DKIM-nycklar…"
 	},
 	"options_saveResult": {
-		"message": "Spara verifieringens resultat"
+		"message": "Spara verifieringsresultatet"
 	},
 	// ---------- DNS options tab ----------
 	"options_dns": {
 		"message": "DNS"
 	},
+	"options_dns.resolver": {
+		"message": "DNS-resolver:"
+	},
+	"options_dns.resolver.value.1": {
+		"message": "DNS-bibliotek i JavaScript"
+	},
 	"options_dns.resolver.value.2": {
 		"message": "libunbound"
+	},
+	"options_dns.resolver.value.3": {
+		"message": "DNS över HTTPS (DoH)",
+		"description": "Resolver using https://en.wikipedia.org/wiki/DNS_over_HTTPS"
+	},
+	"options_dns.getNameserversFromOS": {
+		"message": "Hämta DNS-servrar från operativsystemets konfiguration"
+	},
+	"options_dns.nameserver": {
+		"message": "DNS-servrar (syntax (EBNF): host[\":port\"]{\";\"host[\":port\"]}):"
+	},
+	"options_dns.timeout_connect": {
+		"message": "Tidsgräns för DNS-anslutning (i sekunder):",
+		"description": "Timeout for the connection to the DNS servers (both establishing the connection and sending/receiving data)"
+	},
+	"options_dns.proxy.enable": {
+		"message": "Använd en proxyserver för att ansluta till DNS-servrarna"
 	},
 	"options_dns.proxy.type": {
 		"message": "Proxytyp:"
@@ -113,8 +390,20 @@
 	"options_dns.proxy.port": {
 		"message": "Port:"
 	},
+	"options_dns.libunbound.nameserver": {
+		"message": "DNS-servrar (syntax (EBNF): IP{\";\"IP}):"
+	},
+	"options_dns.libunbound.usageWarning": {
+		"message": "DNS-resolvern libunbound kräver ett externt installerat bibliotek"
+	},
 	"options_dns.libunbound.path": {
 		"message": "Sökväg"
+	},
+	"options_dns.libunbound.path.relToProfileDir": {
+		"message": "Sökväg relativt profilmappen"
+	},
+	"options_dns.doh.server": {
+		"message": "DoH-server:"
 	},
 	// ---------- Policy options tab ----------
 	"options_general.policy": {
@@ -126,27 +415,82 @@
 	"options_policy.signRules.checkDefaultRules": {
 		"message": "Använd standardregler"
 	},
-	"options_policy.signRules.autoAddRule": {
-		"message": "Lägg automatiskt till regler baserat på lästa DKIM-signerade e-postmeddelanden"
+	"options_policy.signRules.autoAddRule.enable": {
+		"message": "Lägg automatiskt till regler baserat på visade DKIM-signerade e-postmeddelanden"
+	},
+	"options_policy.signRules.autoAddRule.onlyIfFromAddressInSDID": {
+		"message": "Endast om Från-adressen tillhör SDID"
+	},
+	"options_policy.signRules.autoAddRule.for.value.0": {
+		"message": "för Från-adressen"
 	},
 	"options_policy.signRules.autoAddRule.for.value.1": {
-		"message": "för underdomän"
+		"message": "för underdomänen"
 	},
 	"options_policy.signRules.autoAddRule.for.value.2": {
-		"message": "för grunddomän"
+		"message": "för basdomänen"
+	},
+	"options_policy.signRules.sdid.allowSubDomains": {
+		"message": "Tillåt även underdomäner till SDID"
+	},
+	"options_policy.signRules.error.wrong_sdid.asWarning": {
+		"message": "Behandla fel SDID som en varning i stället för ett fel"
+	},
+	"options_viewSigners": {
+		"message": "Signeringsregler…"
+	},
+	"options_viewSignerDefaults": {
+		"message": "Standardsigneringsregler…"
+	},
+	"options_policy.DMARC.shouldBeSigned.enable": {
+		"message": "Använd DMARC för att heuristiskt avgöra om ett e-postmeddelande bör vara signerat"
+	},
+	"options_policy.dkim.unsignedHeadersWarning.mode": {
+		"message": "Varna för osignerade huvudfält som rekommenderas att signeras:",
+		"description": "Description for the setting of the unsigned headers warning mode."
+	},
+	"options_policy.dkim.unsignedHeadersWarning.mode.relaxed": {
+		"message": "tolerant läge",
+		"description": "A relaxed mode that will try to avoid showing warnings."
+	},
+	"options_policy.dkim.unsignedHeadersWarning.mode.recommended": {
+		"message": "rekommenderat läge",
+		"description": "A mode trying to enforce best practice without showing to many warnings."
+	},
+	"options_policy.dkim.unsignedHeadersWarning.mode.strict": {
+		"message": "strikt läge",
+		"description": "A strict mode that will potentially show a lot of warnings."
 	},
 	// -------------------- Display options --------------------
 	"options_display": {
 		"message": "Visning"
 	},
+	"options_showDKIMHeader": {
+		"message": "Visa DKIM-huvudfält:"
+	},
+	"options_showDKIMFromTooltip": {
+		"message": "Visa DKIM-verktygstips för Från-huvudfältet:"
+	},
 	"options_showDKIM.value.0": {
 		"message": "aldrig"
 	},
+	"options_showDKIM.value.10": {
+		"message": "när ett e-postmeddelande med en giltig DKIM-signatur visas"
+	},
+	"options_showDKIM.value.30": {
+		"message": "när ett e-postmeddelande med en DKIM-signatur visas"
+	},
+	"options_showDKIM.value.33": {
+		"message": "när ett e-postmeddelande med en DKIM-signatur eller ett SPF- eller DMARC-resultat visas"
+	},
 	"options_showDKIM.value.40": {
-		"message": "när ett e-postmeddelande läses"
+		"message": "när ett e-postmeddelande visas"
 	},
 	"options_showDKIM.value.50": {
-		"message": "när ett meddelande läses"
+		"message": "när ett meddelande visas"
+	},
+	"options_colorFrom": {
+		"message": "Aktivera markering av Från-huvudfältet"
 	},
 	"options_color": {
 		"message": "Färg"
@@ -156,6 +500,10 @@
 	},
 	"options_color.background": {
 		"message": "Bakgrund:"
+	},
+	"options_color.preview": {
+		"message": "förhandsvisning",
+		"description": "Text used to preview the colors for the from highlighting"
 	},
 	"options_color.success": {
 		"message": "Giltig signatur"
@@ -172,22 +520,74 @@
 	"options_color.nosig": {
 		"message": "Osignerat e-postmeddelande"
 	},
+	"options_display.favicon.show": {
+		"message": "Visa webbplatsikonen för kända signeringsdomäner före Från-adressen"
+	},
 	// -------------------- Advanced options --------------------
 	"options_advanced": {
 		"message": "Avancerat"
 	},
+	"options_debug": {
+		"message": "Aktivera felsökning (skriver fel och felsökningsinformation till felkonsolen)"
+	},
 	"options_error.detailedReasons": {
 		"message": "Visa detaljerade felorsaker"
 	},
+	"options_error.key_testmode.ignore": {
+		"message": "Verifiera signaturen ändå om en domän endast testar DKIM"
+	},
+	"options_error.illformed_i.treatAs": {
+		"message": "Behandla en felaktigt utformad AUID-tagg som:"
+	},
+	"options_error.illformed_s.treatAs": {
+		"message": "Behandla en felaktigt utformad väljartagg som:"
+	},
+	"options_error.policy.key_insecure.treatAs": {
+		"message": "Behandla en DKIM-nyckel som inte skyddas av DNSSEC som:"
+	},
+	"options_error.algorithm.sign.rsa-sha1.treatAs": {
+		"message": "Behandla signaturalgoritmen RSA-SHA1 som:"
+	},
+	"options_error.algorithm.rsa.weakKeyLength.treatAs": {
+		"message": "Behandla svaga RSA-nycklar (<2048 bitar) som:"
+	},
+	"options_error.treatAs.value.0": {
+		"message": "fel"
+	},
+	"options_error.treatAs.value.1": {
+		"message": "varning"
+	},
+	"options_error.treatAs.value.2": {
+		"message": "ingenting"
+	},
+	"options_display.keySecure": {
+		"message": "Visa lyckad DNSSEC-verifiering med ett lås efter SDID"
+	},
+	"options_arh.read": {
+		"message": "Läs huvudfältet Authentication-Results"
+	},
+	"options_arh.replaceAddonResult": {
+		"message": "Resultatet från huvudfältet Authentication-Results ersätter tilläggets verifieringsresultat"
+	},
+	"options_arh.relaxedParsing": {
+		"message": "Försök läsa huvudfältet Authentication-Results även om det inte följer RFC"
+	},
 	// -------------------- Account options --------------------
+	"options_account": {
+		"message": "Konto",
+		"description": "Title for account specific options"
+	},
 	"options_acc.dkim.enable": {
 		"message": "Verifiera DKIM-signaturer:"
 	},
+	"options_acc.arh.read": {
+		"message": "Läs huvudfältet Authentication-Results:"
+	},
 	"options_acc.arh.allowedAuthserv": {
-		"message": "Pålitliga autentiseringsservrar:"
+		"message": "Betrodda autentiseringsservrar:"
 	},
 	"options_acc.boolean.value.0": {
-		"message": "Använd standardvärde"
+		"message": "Använd standardvärdet"
 	},
 	"options_acc.boolean.value.1": {
 		"message": "Ja"
@@ -196,13 +596,120 @@
 		"message": "Nej"
 	},
 	// -------------------- About --------------------
+	"about": {
+		"message": "Om"
+	},
+	"about_name": {
+		"message": "DKIM Verifier",
+		"description": "Name of the add-on"
+	},
 	"about_summary": {
-		"message": "Verifierar DKIM-signaturen för e-postmeddelande.",
+		"message": "Verifierar DKIM-signaturer i e-postmeddelanden.",
 		"description": "Short description of the add-on"
 	},
+	"about_homepage": {
+		"message": "Webbplats"
+	},
+	"about_documentation": {
+		"message": "Dokumentation",
+		"description": "Link text for GitHub documentation page"
+	},
+	"about_contributors": {
+		"message": "GitHub-bidragsgivare",
+		"description": "Link text for GitHub contributors page"
+	},
+	"about_translators": {
+		"message": "Översättare:",
+		"description": "Heading for list of translators"
+	},
+	"about_dependencies": {
+		"message": "Inkluderade beroenden:",
+		"description": "Heading for list of included dependencies"
+	},
+	"about_by": {
+		"message": "av",
+		"description": "<dependency name> by <author>"
+	},
 	// ==================== Actions ====================
+	"dkim_verifier.reverifyDKIMSignature": {
+		"message": "Verifiera DKIM-signaturen igen",
+		"description": "Text of the button in the DKIM details pop-up."
+	},
+	"dkim_verifier.reverifyDKIMSignature.tooltip": {
+		"message": "Startar en ny verifiering av det visade e-postmeddelandet. Om verifieringsresultatet sparas uppdateras även det sparade resultatet.",
+		"description": "Tooltip of the button explaining what it does."
+	},
+	"dkim_verifier.policyAddUserException": {
+		"message": "Lägg till undantag från signeringskravet",
+		"description": "Text of the button in the DKIM details pop-up."
+	},
+	"dkim_verifier.policyAddUserException.tooltip": {
+		"message": "Lägg till en signeringsregel som anger att e-postmeddelanden från Från-adressen inte behöver vara signerade. En ny verifiering startas också.",
+		"description": "Tooltip of the button explaining what it does."
+	},
+	"dkim_verifier.markKeyAsSecure": {
+		"message": "Markera DKIM-nyckeln som säker",
+		"description": "Text of the button in the DKIM details pop-up."
+	},
+	"dkim_verifier.markKeyAsSecure.tooltip": {
+		"message": "Markera den cachade DKIM-nyckeln för det första DKIM-resultatet som skyddad av DNSSEC. En ny verifiering startas också.",
+		"description": "Tooltip of the button explaining what it does."
+	},
 	"dkim_verifier.updateKey": {
-		"message": "Uppdatera DKIM-nyckel"
+		"message": "Uppdatera DKIM-nyckeln",
+		"description": "Text of the button in the DKIM details pop-up."
+	},
+	"dkim_verifier.updateKey.tooltip": {
+		"message": "Uppdatera de cachade DKIM-nycklar som används för det här e-postmeddelandet genom att hämta dem från DNS igen. En ny verifiering startas också.",
+		"description": "Tooltip of the button explaining what it does."
+	},
+	"button.options": {
+		"message": "Inställningar",
+		"description": "Button to open the options page of the add-on."
+	},
+	"button.options.tooltip": {
+		"message": "Öppna tilläggets inställningar i en ny flik.",
+		"description": "Tooltip for the button to open the options page of the add-on."
+	},
+	"details.result": {
+		"message": "Resultat",
+		"description": "Detailed view row name for the overall DKIM result."
+	},
+	"details.warnings": {
+		"message": "Varningar",
+		"description": "Detailed view row name for the warnings of the DKIM signature."
+	},
+	"details.SDID": {
+		"message": "SDID",
+		"description": "Detailed view row name for the SDID."
+	},
+	"details.AUID": {
+		"message": "AUID",
+		"description": "Detailed view row name for the AUID."
+	},
+	"details.signDate": {
+		"message": "Signeringstid",
+		"description": "Detailed view row name for the date (including time) the signature was created."
+	},
+	"details.expirationDate": {
+		"message": "Utgångstid",
+		"description": "Detailed view row name for the date (including time) the signature expires."
+	},
+	"details.algorithm": {
+		"message": "Algoritm",
+		"description": "Detailed view row name for the algorithm used in the signature."
+	},
+	"details.signedHeaders": {
+		"message": "Signerade huvudfält",
+		"description": "Detailed view row name for the message headers signed by DKIM."
+	},
+	"details.noDate": {
+		"message": "Ingen tidsstämpel ingår i signaturen",
+		"description": "Value shown for sign and expiration date if no date is given in the signature."
+	},
+	"details.potentiallyOutdatedKeyWarning": {
+		"message": "Mellanlagring av DKIM-nycklar är aktiverad. Den ogiltiga signaturen kan bero på en inaktuell nyckel. Använd åtgärden ”$1” för att uppdatera nyckeln och starta en ny verifiering.",
+		"description": "Potential info note shown. $1 will be replaced with the text of dkim_verifier.updateKey"
 	},
 	// ==================== Table Views ====================
 	"treeviewKeys.title": {
@@ -212,11 +719,14 @@
 	"treeviewKeys.treecol.SDID": {
 		"message": "SDID"
 	},
+	"treeviewKeys.treecol.selector": {
+		"message": "Väljare"
+	},
 	"treeviewKeys.treecol.key": {
 		"message": "DKIM-nyckel"
 	},
 	"treeviewKeys.treecol.insertedAt": {
-		"message": "Infogad"
+		"message": "Tillagd"
 	},
 	"treeviewKeys.treecol.lastUsedAt": {
 		"message": "Senast använd"
@@ -225,13 +735,19 @@
 		"message": "DNSSEC"
 	},
 	"treeviewKeys.deleteSelectedRows": {
-		"message": "Radera valda nycklar"
+		"message": "Ta bort valda nycklar"
+	},
+	"treeviewSigners.user.title": {
+		"message": "Signeringsregler"
+	},
+	"treeviewSigners.default.title": {
+		"message": "Standardsigneringsregler"
 	},
 	"treeviewSigners.treecol.domain": {
 		"message": "Domän"
 	},
-	"treeviewSigners.treecol.listID": {
-		"message": "List-ID"
+	"treeviewSigners.treecol.listId": {
+		"message": "List-Id"
 	},
 	"treeviewSigners.treecol.addr": {
 		"message": "Från"
@@ -251,8 +767,35 @@
 	"treeviewSigners.addSignersRule": {
 		"message": "Lägg till regel…"
 	},
+	"treeviewSigners.deleteSelectedRows": {
+		"message": "Ta bort valda regler"
+	},
+	"treeviewSigners.exportRules": {
+		"message": "Exportera regler…",
+		"description": "Button for exporting sign rules"
+	},
+	"treeviewSigners.importRules": {
+		"message": "Importera regler…",
+		"description": "Button for importing sign rules"
+	},
+	"importRules.title": {
+		"message": "Importera regler",
+		"description": "Title for import dialog"
+	},
+	"importRules.replaceQuestion": {
+		"message": "Ska de importerade reglerna läggas till i de befintliga reglerna eller ersätta dem?",
+		"description": "Question asked in import dialog"
+	},
+	"importRules.addRules": {
+		"message": "Lägg till regler",
+		"description": "Button in import dialog for adding rules to existing rules"
+	},
+	"importRules.replaceRules": {
+		"message": "Ersätt regler",
+		"description": "Button in import dialog for replacing existing rules"
+	},
 	"addSignersRule.title": {
-		"message": "Lägg till signaturregel"
+		"message": "Lägg till signeringsregel"
 	},
 	"addSignersRule.button.add": {
 		"message": "Lägg till regel",
@@ -262,19 +805,52 @@
 		"message": "Måste vara signerad (1)"
 	},
 	"signRules.ruletype.NEUTRAL": {
-		"message": "Kan signeras (2)"
+		"message": "Kan vara signerad (2)"
+	},
+	"signRules.ruletype.HIDEFAIL": {
+		"message": "Ignorera ogiltig signatur (3)"
+	},
+	"signRules.priorityMode.auto": {
+		"message": "Välj prioritet automatiskt"
 	},
 	"signRules.priorityMode.manual": {
-		"message": "Ändra prioritet till:"
+		"message": "Ange prioritet:"
+	},
+	"button.cancel": {
+		"message": "Avbryt"
 	},
 	"button.help": {
 		"message": "Hjälp…"
+	},
+	"signersRuleHelp.title": {
+		"message": "Hjälp för signeringsregler"
+	},
+	"domain.description": {
+		"message": "Matchas mot basdomänen för Från-adressen. Basdomänen för ”email.example.co.uk” är till exempel ”example.co.uk”."
+	},
+	"listId.description": {
+		"message": "Matchas mot List-Id om e-postmeddelandet togs emot via en e-postlista. Observera att endast delen mellan ”<” och ”>” i huvudfältet List-Id utgör det faktiska List-Id-värdet. Endast antingen domänen eller List-Id matchas åt gången."
+	},
+	"addr.description": {
+		"message": "Matchas mot Från-adressen. Använd ”*” för att matcha noll eller flera tecken."
+	},
+	"sdid.description": {
+		"message": "Domänen som e-postmeddelandena ska vara signerade av. Om fältet lämnas tomt tillåts alla SDID. Flera domäner kan anges genom att skilja dem åt med mellanslag."
 	},
 	"ruletype.description": {
 		"message": "Regelns typ."
 	},
 	"ruletype.1.description": {
-		"message": "E-postmeddelande måste vara signerade med angivet SDID."
+		"message": "E-postmeddelandet måste vara signerat med angivet SDID."
+	},
+	"ruletype.2.description": {
+		"message": "E-postmeddelandet behöver inte vara signerat. Om det är signerat måste det vara signerat med angivet SDID."
+	},
+	"ruletype.3.description": {
+		"message": "E-postmeddelandet behöver inte vara signerat. Om det är signerat måste det vara signerat med angivet SDID. Om e-postmeddelandet har en ogiltig signatur behandlas det som om det saknar signatur."
+	},
+	"priority.description": {
+		"message": "Regelns prioritet. Om flera regler matchar används den med högst prioritet."
 	},
 	"enabled.description": {
 		"message": "1 om regeln är aktiverad, 0 om den är inaktiverad."


### PR DESCRIPTION
# Complete and update Swedish translation for DKIM Verifier

This PR updates and completes the Swedish localization for DKIM Verifier against the current English source.

## Changes

* Added translations for 177 previously missing strings
* Reviewed and improved 22 existing Swedish translations
* Updated the Swedish locale to match all 260 current localization keys
* Removed obsolete keys that are no longer present in the English source
* Improved consistency for DKIM, DNS, signing rules, headers, SDID, AUID, and verification terminology
* Translated newer DKIM and DNS error messages, policy settings, account options, detailed result views, and signing-rule management
* Preserved all placeholders and source descriptions
* Validated the resulting JSON5 structure

The goal of this PR is to bring the Swedish translation fully up to date while improving consistency and natural Swedish wording throughout the add-on.
