### PR TITLE
2.x: Fix colorpicker in Charamel theme

### DIFF
--- a/chrome/skin/global/options.css
+++ b/chrome/skin/global/options.css
@@ -2,3 +2,7 @@ checkbox {white-space: pre;}
 #paneDisplay [anonid="gridHeader"] {
 	text-align: end;
 }
+
+.colorpicker-button-menupopup, .colorpicker-button-menupopup * {
+	-moz-user-select: none !important;
+}


### PR DESCRIPTION
This fixes the problem, that mouse selection in color picker dialogs doesn't work in Charamel theme